### PR TITLE
Add role and group management to Keycloak integration

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -1,0 +1,106 @@
+package keycloak
+
+import "fmt"
+
+type Group struct {
+	ID            string        `json:"id"`
+	Name          string        `json:"name"`
+	Path          string        `json:"path"`
+	SubGroupCount int           `json:"subGroupCount"`
+	SubGroups     []interface{} `json:"subGroups"`
+	Access        struct {
+		View             bool `json:"view"`
+		ViewMembers      bool `json:"viewMembers"`
+		ManageMembers    bool `json:"manageMembers"`
+		Manage           bool `json:"manage"`
+		ManageMembership bool `json:"manageMembership"`
+	} `json:"access"`
+	RealmRoles []string `json:"realmRoles"`
+}
+
+func (connection *Connection) GetGroups() ([]Group, error) {
+	result, err := connection.Get("/admin", "/groups?first=0&max=9999")
+	if err != nil {
+		return nil, err
+	}
+	var groups []Group
+	err = result.ToJSON(&groups)
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+func GetGroups() ([]Group, error) {
+	return conn.GetGroups()
+}
+
+func (connection *Connection) GetGroup(id string) (*Group, error) {
+	result, err := connection.Get("/admin", "/groups/"+id)
+	if err != nil {
+		return nil, err
+	}
+	var group Group
+	err = result.ToJSON(&group)
+	if err != nil {
+		return nil, err
+	}
+	return &group, nil
+}
+
+func GetGroup(id string) (*Group, error) {
+	return conn.GetGroup(id)
+}
+
+func (connection *Connection) CreateGroup(group *Group) error {
+	result, err := connection.Post("/admin", "/groups", group)
+	if err != nil {
+		return err
+	}
+	var createdGroup Group
+	err = result.ToJSON(&createdGroup)
+	if err != nil {
+		return err
+	}
+	if createdGroup.ID == "" {
+		return fmt.Errorf("expected group ID, got empty string")
+	}
+	group.ID = createdGroup.ID
+	group.Path = createdGroup.Path
+	return nil
+}
+
+func CreateGroup(group *Group) error {
+	return conn.CreateGroup(group)
+}
+
+func (connection *Connection) UpdateGroup(group *Group) error {
+	result, err := connection.Put("/admin", "/groups/"+group.ID, group)
+	if err != nil {
+		return err
+	}
+	var updatedGroup Group
+	err = result.ToJSON(&updatedGroup)
+	if err != nil {
+		return err
+	}
+	if updatedGroup.ID != group.ID {
+		return fmt.Errorf("expected group ID %s, got %s", group.ID, updatedGroup.ID)
+	}
+	group.ID = updatedGroup.ID
+	group.Path = updatedGroup.Path
+	return nil
+}
+
+func UpdateGroup(group *Group) error {
+	return conn.UpdateGroup(group)
+}
+
+func (connection *Connection) DeleteGroup(id string) error {
+	_, err := connection.Delete("/admin", "/groups/"+id)
+	return err
+}
+
+func DeleteGroup(id string) error {
+	return conn.DeleteGroup(id)
+}

--- a/roles.go
+++ b/roles.go
@@ -1,0 +1,112 @@
+package keycloak
+
+import "github.com/getevo/evo/v2/lib/curl"
+
+type Role struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Composite   bool   `json:"composite"`
+	ClientRole  bool   `json:"clientRole"`
+	ContainerID string `json:"containerId"`
+}
+
+func (connection *Connection) GetRoles() ([]Role, error) {
+	result, err := connection.Get("/admin", "/roles?first=0&max=9999", curl.Header{
+		"Authorization": "Bearer " + connection.Admin.AccessToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var roles []Role
+	err = result.ToJSON(&roles)
+	if err != nil {
+		return nil, err
+	}
+	return roles, nil
+}
+
+func GetRoles() ([]Role, error) {
+	return conn.GetRoles()
+}
+
+func (connection *Connection) GetRole(id string) (Role, error) {
+	var role Role
+	result, err := connection.Get("/admin", "/roles-by-id/"+id, curl.Header{
+		"Authorization": "Bearer " + connection.Admin.AccessToken,
+	})
+	if err != nil {
+		return role, err
+	}
+
+	err = result.ToJSON(&role)
+	if err != nil {
+		return role, err
+	}
+	return role, nil
+}
+
+func GetRole(id string) (Role, error) {
+	return conn.GetRole(id)
+}
+
+func (connection *Connection) CreateRole(name, description string) (Role, error) {
+	var role Role
+	payload := map[string]interface{}{
+		"name":        name,
+		"description": description,
+		"composite":   false,
+		"clientRole":  false,
+	}
+	result, err := connection.Post("/admin", "/roles", payload, curl.Header{
+		"Authorization": "Bearer " + connection.Admin.AccessToken,
+	})
+	if err != nil {
+		return role, err
+	}
+
+	err = result.ToJSON(&role)
+	if err != nil {
+		return role, err
+	}
+	return role, nil
+}
+
+func CreateRole(name, description string) (Role, error) {
+	return conn.CreateRole(name, description)
+}
+
+func (connection *Connection) UpdateRole(roleID, name, description string) (Role, error) {
+	var role Role
+	payload := map[string]interface{}{
+		"name":        name,
+		"description": description,
+	}
+	result, err := connection.Put("/admin", "/roles-by-id/"+roleID, payload, curl.Header{
+		"Authorization": "Bearer " + connection.Admin.AccessToken,
+	})
+	if err != nil {
+		return role, err
+	}
+
+	err = result.ToJSON(&role)
+	if err != nil {
+		return role, err
+	}
+	return role, nil
+}
+
+func UpdateRole(roleID, name, description string) (Role, error) {
+	return conn.UpdateRole(roleID, name, description)
+}
+
+func (connection *Connection) DeleteRole(roleID string) error {
+	_, err := connection.Delete("/admin", "/roles-by-id/"+roleID, curl.Header{
+		"Authorization": "Bearer " + connection.Admin.AccessToken,
+	})
+	return err
+}
+
+func DeleteRole(roleID string) error {
+	return conn.DeleteRole(roleID)
+}


### PR DESCRIPTION
Replaced outdated permission handlers with new role and group management endpoints. Introduced CRUD operations for roles and groups within the Keycloak integration to enhance admin capabilities. Updated routing in `app.go` to reflect the new API structure.